### PR TITLE
Pin Pre-Commit NodeJS to v22 (.10.0), update ESLint hook and test Netlify

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ minimum_pre_commit_version: '2.10.0'
 
 default_language_version:
   python: python3
+  node: '22.10.0'
 
 default_stages: [commit]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,14 +95,14 @@ repos:
 
 # Lint and fix JavaScript
 - repo: https://github.com/eslint/eslint
-  rev: v9.9.0  # Pin to fix dep conflict on install; see eslint/eslint#18956
+  rev: v9.12.0
   hooks:
   - id: eslint
     name: Lint and fix JavaScript (ESLint)
     args: [--fix, --color, --max-warnings, '0']
     additional_dependencies:
-    - 'eslint-plugin-import@2.30.0'
-    - 'eslint-plugin-n@17.10.3'
+    - '@stylistic/eslint-plugin@2.9.0'
+    - 'eslint-plugin-n@17.11.1'
     - 'eslint-plugin-promise@7.1.0'
     - 'neostandard@0.11.6'
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Build](https://github.com/spyder-ide/spyder-api-docs/actions/workflows/build.yaml/badge.svg)](https://github.com/spyder-ide/spyder-api-docs/actions/workflows/build.yaml)
 [![Check](https://github.com/spyder-ide/spyder-api-docs/actions/workflows/check.yaml/badge.svg)](https://github.com/spyder-ide/spyder-api-docs/actions/workflows/check.yaml)
 [![Lint](https://github.com/spyder-ide/spyder-api-docs/actions/workflows/lint.yaml/badge.svg)](https://github.com/spyder-ide/spyder-api-docs/actions/workflows/lint.yaml)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/_FIXME_NETLIFY_PROJECT_ID/deploy-status)](https://app.netlify.com/sites/spyder-api-docs-preview/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/e8229c2b-a95c-4bac-876d-61cd286c62e8/deploy-status)](https://app.netlify.com/sites/spyder-api-docs-preview/deploys)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Nox](https://img.shields.io/badge/%F0%9F%A6%8A-Nox-D85E00.svg)](https://github.com/wntrblm/nox)
 [![OpenCollective Backers](https://opencollective.com/spyder/backers/badge.svg?color=blue)](https://opencollective.com/spyder)


### PR DESCRIPTION
# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-api-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch
* [x] Checked your code and writing carefully
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

- Pin NodeJS in Pre-COmmit to the latest 22.x release, 22.10.0, due to multiple local (at least) breakages with 23.0.0
- Update ESLint from 2.9.0 to 2.12.0 now that the latter version fixed the error introduced in 2.9.1, eslint/eslint#18956
- Test the newly-enabled Netlify site deploy previews and add the appropriate Readme status badge

<!--- Thanks for your help making Spyder-API-Docs better for everyone! --->
