### PR TITLE
Automatically generate API docs from a Spyder repo submodule

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 count = True
-ignore = E123, E203, W504
+ignore = E123, E203, W503
 max-doc-length = 79
 max-complexity = 15
 jobs = 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    name: Build and Deploy
+    name: Build and Deploy Autodoc=${{ matrix.build-autodoc }}
 
     runs-on: ubuntu-latest
 
@@ -28,10 +28,18 @@ jobs:
       IS_DEPLOY: ${{ (github.event_name == 'push' && '1') || '0' }}
       IS_STAGING: ${{ (github.ref == 'refs/heads/staging' && '1') || '0' }}
       IS_MAIN: ${{ ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && '1') || '0' }}
+      BUILD_AUTODOC: ${{ matrix.build-autodoc }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build-autodoc: ['Yes', 'No']
 
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -45,12 +53,13 @@ jobs:
         echo Deploy: $IS_DEPLOY
         echo Prod: $IS_PROD
         echo Main: $IS_MAIN
+        echo Autodoc: $BUILD_AUTODOC
         pip list
     - name: Build project
       shell: bash
       run: ./ci/build.sh
     - name: Deploy to GitHub Pages
-      if: env.IS_DEPLOY == '1'
+      if: env.IS_DEPLOY == '1' && env.BUILD_AUTODOC == 'Yes'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs/_build/html

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,9 @@ instance/
 .scrapy
 
 # Sphinx documentation
+doc/_autosummary/
 doc/_build/
+docs/_autosummary/
 docs/_build/
 
 # PyBuilder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "spyder"]
+	path = spyder
+	url = https://github.com/spyder-ide/spyder.git
+	branch = 6.x
+	update = rebase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Regardless of the tool you use, make sure to remember to always activate your en
 
 #### Conda
 
-To create an environment with Conda (recommended), simply execute the following:
+To create an environment with Conda (recommended), execute the following:
 
 ```shell
 conda create -c conda-forge -n spyder-api-docs-env python
@@ -194,7 +194,12 @@ Or if using ``pip``, you can grab them with:
 python -m pip install -r requirements.txt
 ```
 
+If you plan to generate and build the API reference documentation extracted from Spyder's docstrings, you'll also need to install Spyder in development mode as well as its dev dependencies.
+To do so, you can run the ``install_dev_repos.py`` script in the ``spyder`` submodule:
 
+```shell
+python install_dev_repos.py
+```
 
 
 ## Installing and Using the Pre-Commit Hooks
@@ -249,7 +254,13 @@ To build the project using Nox, just run
 nox -s build
 ```
 
-and can then open the rendered output in your default web browser with
+or, to also extract, generate and build the API reference from Spyder's docstrings (expensive the first time), pass the ``-t autodoc`` argument to any build command:
+
+```shell
+nox -s build -- -t autodoc
+```
+
+and then open the rendered output in your default web browser with
 
 ```shell
 nox -s serve
@@ -258,7 +269,7 @@ nox -s serve
 Alternatively, to automatically rebuild the project when changes occur, you can invoke
 
 ```shell
-nox -s autobuild
+nox -s autorebuild
 ```
 
 You can also pass your own custom [Sphinx build options](https://www.sphinx-doc.org/en/master/man/sphinx-build.html) after a ``--`` separator, which are added to the default set.
@@ -266,6 +277,12 @@ For example, to rebuild just the install guide and FAQ in verbose mode with the 
 
 ```shell
 nox -s build -- --verbose --builder dirhtml -- index.rst
+```
+
+When changing build options (particularly autodoc), cleaning the generated files avoids spurious errors:
+
+```shell
+nox -s clean
 ```
 
 
@@ -277,7 +294,20 @@ For manual installations, you can invoke Sphinx yourself with the appropriate op
 python -m sphinx -n -W --keep-going docs docs/_build/html
 ```
 
+or to also extract, generate and build the API reference from Spyder's docstrings (requires Spyder and its dependencies to be installed in your environment):
+
+```shell
+python -I -m sphinx -n --keep-going -t autodoc docs docs/_build/html
+```
+
 Then, navigate to the ``_build/html`` directory inside the ``spyder-docs`` repository and open ``index.html`` (the main page of the docs) in your preferred browser.
+
+When changing build options (particularly autodoc), cleaning the generated files first avoids spurious errors:
+
+```shell
+rm -r docs/_autosummary/
+rm -r docs/_build/
+```
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ Let us know if you have any further questions, and we look forward to your contr
 - [Cloning the Repository](#cloning-the-repository)
 - [Setting Up a Development Environment with Nox (Recommended)](#setting-up-a-development-environment-with-nox-recommended)
 - [Setting Up a Development Environment Manually](#setting-up-a-development-environment-manually)
+  - [Configure Git](#configure-git)
   - [Create and activate a fresh environment](#create-and-activate-a-fresh-environment)
   - [Install dependencies](#install-dependencies)
-  - [Add the upstream remote](#add-the-upstream-remote)
 - [Installing and Using the Pre-Commit Hooks](#installing-and-using-the-pre-commit-hooks)
 - [Building the Project](#building-the-project)
   - [Build with Nox](#build-with-nox)
@@ -35,7 +35,8 @@ Let us know if you have any further questions, and we look forward to your contr
 - [Contributing Changes](#contributing-changes)
   - [Decide which branch to use](#decide-which-branch-to-use)
   - [Prepare your topic branch](#prepare-your-topic-branch)
-  - [Commit your changes](#commit-your-changes)
+  - [Sync the latest Spyder docstrings (optional)](#sync-the-latest-spyder-docstrings-optional)
+  - [Make and commit your changes](#make-and-commit-your-changes)
   - [Push your branch](#push-your-branch)
   - [Submit a Pull Request](#submit-a-pull-request)
 - [Standards and Conventions](#standards-and-conventions)
@@ -58,10 +59,10 @@ If referring to a specific line or file, please be sure to provide a snippet of 
 ## Cloning the Repository
 
 First, navigate to the [project repository](https://github.com/spyder-ide/spyder-api-docs) in your web browser and press the ``Fork`` button to make a personal copy of the repository on your own GitHub account.
-Then, click the ``Clone or Download`` button on your repository, copy the link and run the following on the command line to clone the repo:
+Then, click the ``Clone or Download`` button on your repository, copy the link and run the following on the command line to clone the repo (with submodules):
 
 ```shell
-git clone <LINK-TO-YOUR-REPO>
+git clone --recurse-submodules <LINK-TO-YOUR-REPO>
 ```
 
 After cloning the repository, navigate to its new directory using the `cd` command:
@@ -117,6 +118,22 @@ You can always switch it later with ``nox -s setup-remotes -- --ssh``.
 For advanced users, if you'd prefer to also have your own local environment with the project dependencies that doesn't go through Nox, you can also set one up yourself.
 
 **Note**: You may need to substitute ``python3`` for ``python`` in the commands below on some Linux distros where ``python`` isn't mapped to ``python3`` (yet).
+
+
+### Configure Git
+
+Make sure to set the upstream Git remote to the official Spyder-API-Docs repo with:
+
+```shell
+git remote add upstream https://github.com/spyder-ide/spyder-api-docs.git
+```
+
+It's also a good idea to configure Git to automatically pull, checkout and push submodules:
+
+```shell
+git config --local submodule.recurse true
+git config --local push.recurseSubmodules check
+```
 
 
 ### Create and activate a fresh environment
@@ -177,14 +194,6 @@ Or if using ``pip``, you can grab them with:
 python -m pip install -r requirements.txt
 ```
 
-
-### Add the upstream remote
-
-Make sure to set the upstream Git remote to the official Spyder-API-Docs repo with:
-
-```shell
-git remote add upstream https://github.com/spyder-ide/spyder-api-docs.git
-```
 
 
 
@@ -295,7 +304,40 @@ git switch -c <FEATURE-BRANCH>
 ```
 
 
-### Commit your changes
+### Sync the latest Spyder docstrings (optional)
+
+*If* your pull request requires the latest docstring changes from the Spyder repo, or there's a reason to manually update them, you can update the submodule to the latest stable branch either with Nox:
+
+```shell
+nox -s sync-spyder
+```
+
+or manually:
+
+```shell
+git submodule update --remote
+```
+
+**Note**: If using the manual command and you've checked out the submodule to a topic branch tracking your fork rather than the upstream Spyder repository, you'll need to either check out `6.x` first (setting it to track the main Spyder repo if it isn't already):
+
+```shell
+cd spyder
+git switch 6.x
+git --set-upstream-to upstream 6.x  # If required
+cd ..
+```
+
+Or, to integrate the changes into your own branch (assuming `upstream` is the Spyder repository):
+
+```shell
+cd spyder
+git fetch upstream 6.x
+git rebase FETCH_HEAD
+cd ..
+```
+
+
+### Make and commit your changes
 
 Once you've made and tested your changes, add them to the staging area, and then commit them with a descriptive message.
 Commit messages should be

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,3 +1,9 @@
 #!/bin/bash -ex
 
-nox -s build
+if [ "$BUILD_AUTODOC" = "No" ]; then
+    ARGS=''
+else
+    ARGS='-t autodoc'
+fi
+
+nox -s build -- $ARGS

--- a/docs/_templates/custom-module-template.rst
+++ b/docs/_templates/custom-module-template.rst
@@ -1,0 +1,63 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {%- if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block functions %}
+   {%- if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block classes %}
+   {%- if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block exceptions %}
+   {%- if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+{%- block modules %}
+{%- if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+{% for item in modules %}
+   {% if not 'tests' in item %}
+       {{ item }}
+   {%- endif %}
+{%- endfor %}
+{% endif %}
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,17 +15,10 @@
 # serve to show the default.
 
 
-# If extensions (or modules to document with autodoc) are in another
-# directory, add these directories to sys.path here. If the directory is
-# relative to the documentation root, use os.path.abspath to make it
-# absolute, like shown here.
-#
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
-
 # Standard library imports
 import datetime
+import sys
+from pathlib import Path
 
 # Third party imports
 from docutils import nodes
@@ -34,6 +27,9 @@ from docutils.parsers.rst import Directive, directives
 
 # Constants
 UTC_DATE = datetime.datetime.now(datetime.timezone.utc)
+
+# Make Spyder available on $PATH for API documentation
+sys.path.insert(0, str(Path(__file__).parents[1].resolve() / "spyder"))
 
 
 # -- General configuration ---------------------------------------------
@@ -47,13 +43,15 @@ needs_sphinx = "5"
 extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = []  # "_templates"
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -101,7 +99,9 @@ pygments_style = "sphinx"
 todo_include_todos = False
 
 # Intersphinx configuration
+# pylint: disable-next = consider-using-namedtuple-or-dataclass
 intersphinx_mapping = {
+    "python": ("https://docs.python.org/", None),
     "spyder": ("https://docs.spyder-ide.org/current/", None),
 }
 
@@ -133,6 +133,9 @@ html_favicon = "_static/favicon.ico"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# Warning suppression
+suppress_warnings = []
 
 
 # -- Options for HTMLHelp output ---------------------------------------
@@ -232,6 +235,35 @@ linkcheck_ignore = [
 # --- Myst parser options
 # See: https://myst-parser.readthedocs.io/
 myst_config = {}
+
+
+# -- Options for Autodoc/Autosummary -----------------------------------
+
+# Include Python objects as they appear in source files
+# Default: alphabetically ('alphabetical')
+autodoc_member_order = "bysource"
+
+# Default flags used by autodoc directives
+autodoc_default_options = {
+    "members": True,
+    "show-inheritance": True,
+}
+
+# Disable imports that cause crashes
+autodoc_mock_imports = [
+    # "qtpy.QtGui",
+    # "qdarkstyle",
+    # "qstylizer",
+]
+
+# Generate autosummaries if the autodoc tag is passed
+# pylint: disable-next = undefined-variable
+if "autodoc" in tags:  # noqa: F821
+    autosummary_generate = True
+else:
+    autosummary_generate = False
+    suppress_warnings += ["autodoc", "autosummary", "toc.excluded"]
+    exclude_patterns += ["reference.rst"]
 
 
 # -- Additional Directives ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,10 +28,7 @@
 import datetime
 
 # Third party imports
-# pylint: disable-next = import-error
 from docutils import nodes
-
-# pylint: disable-next = import-error
 from docutils.parsers.rst import Directive, directives
 
 
@@ -43,7 +40,7 @@ UTC_DATE = datetime.datetime.now(datetime.timezone.utc)
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = "1.0"
+needs_sphinx = "5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named "sphinx.ext.*") or your custom ones.
@@ -215,7 +212,7 @@ texinfo_documents = [
 # }
 
 
-# -- Options for Linkcheck --------------------------------------------------
+# -- Options for Linkcheck ---------------------------------------------
 
 linkcheck_ignore = [
     # Virtual fragment ids
@@ -299,7 +296,6 @@ class Youtube(IFrameVideo):
             '<iframe src="https://www.youtube.com/embed/%(video_id)s',
             '?start=%(start)s" ',
             'width="%(width)u" height="%(height)u" frameborder="0" ',
-            # pylint: disable = inconsistent-quotes
             "webkitAllowFullScreen mozallowfullscreen allowfullscreen ",
             'class="align-%(align)s"></iframe></div></div>',
         ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,4 +40,5 @@ Plugin Development with Spyder <plugin_development>
 Extending Spyder <common_extension_points>
 Design Patterns <design_patterns>
 FAQ <faq>
+API Reference <reference>
 ```

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -5,6 +5,7 @@ API reference for all modules in the Spyder application.
 
 .. autosummary::
    :toctree: _autosummary
+   :template: custom-module-template.rst
    :recursive:
 
    spyder.api

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,0 +1,10 @@
+API Reference
+=============
+
+API reference for all modules in the Spyder application.
+
+.. autosummary::
+   :toctree: _autosummary
+   :recursive:
+
+   spyder.api

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,15 +4,15 @@
 import contextlib
 import logging
 import os
-import tempfile
 import shutil
 import sys
+import tempfile
 import webbrowser
 from pathlib import Path
 
 # Third party imports
-import nox  # pylint: disable=import-error
-import nox.logger  # pylint: disable=import-error
+import nox
+import nox.logger
 
 
 # --- Global constants --- #
@@ -230,7 +230,7 @@ def _run(session):
     session.run(*posargs)
 
 
-@nox.session()
+@nox.session
 def run(session):
     """Run any command."""
     session.notify("_execute", posargs=([_run], *session.posargs))
@@ -485,7 +485,6 @@ def serve_docs(_session):
 def _prepare_multiversion(_session=None):
     """Execute the pre-deployment steps for multi-version support."""
     # pylint: disable=import-outside-toplevel
-    # pylint: disable=import-error
 
     sys.path.append(str(SCRIPT_DIR))
     import generateredirects

--- a/tutorial/my-spyder-plugin/my_spyder_plugin/plugin.py
+++ b/tutorial/my-spyder-plugin/my_spyder_plugin/plugin.py
@@ -1,3 +1,5 @@
+# pylint: disable = no-name-in-module
+
 # Third party imports
 from spyder.api.plugins import Plugins, SpyderPluginV2
 from spyder.plugins.core.api import ApplicationMenus, HelpMenuSections


### PR DESCRIPTION
# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-api-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch
* [x] Checked your code and writing carefully
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

Adds the Spyder repo as a submodule, sets up the infra to generate API docs from it using Sphinx-Autosummary, and adds a bunch of new Nox commands and CONTRIBUTING guide instructions to take advantage of it.

~Might need some pre-commit fixes as its been some time since the hooks have been updated.~ Done, also did some further rebasing and cleanup.

EDIT: Also added separate GitHub Actions jobs for builds with and without the autodoc generation, to verify that both work properly, isolate any issues and check our own docs here with warnings and broken references treated as errors, while not failing (yet) on such in docstrings.

<!--- Thanks for your help making Spyder-API-Docs better for everyone! --->
