### PR TITLE
Fix errors in spyder.api docstrings & add __all__ to show exports

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -165,7 +165,7 @@ def construct_sphinx_invocation(
     build_dir = BUILD_DIR / builder if build_dir is None else build_dir
 
     if "autodoc" in cli_options:
-        build_options = [item for item in build_options if item != "-W"]
+        build_options = [item for item in build_options if item != "-n"]
 
     if CI:
         build_options = list(build_options) + ["--color"]


### PR DESCRIPTION
# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-api-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch
* [x] Checked your code and writing carefully
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

<!--- Describe what you've changed and why. --->

Depends on spyder-ide/spyder#25388 which should be merged first and this rebased.

Integrates those changes to fix all syntax errors and warnings in `spyder.api` docstrings, add `__all__` for explicit exports and fix those warnings, and also in this repo now catch and fail on new syntax warnings in the docstring build.


<!--- Thanks for your help making Spyder-API-Docs better for everyone! --->
