### PR TITLE
Revise docstrings for modules, fix ref errors, hide private modules & add env var

### DIFF
--- a/docs/_templates/custom-module-template.rst
+++ b/docs/_templates/custom-module-template.rst
@@ -55,7 +55,8 @@
    :template: custom-module-template.rst
    :recursive:
 {% for item in modules %}
-   {% if not 'tests' in item %}
+   {%- set item_fullname %}{{ fullname }}.{{ item }}{% endset %}
+   {%- if not (ignore_module_pattern in item or item_fullname in ignore_modules) %}
        {{ item }}
    {%- endif %}
 {%- endfor %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -256,6 +256,17 @@ autodoc_mock_imports = [
     # "qstylizer",
 ]
 
+# Set list of modules and patterns to ignore in the autosummary template
+autosummary_context = {
+    "ignore_module_pattern": "tests",
+    "ignore_modules": [
+        "spyder.api.editor",
+        "spyder.api.plugins.enum",
+        "spyder.api.plugins.new_api",
+        "spyder.api.plugins.tests",
+    ],
+}
+
 # Generate autosummaries if the autodoc tag is passed
 # pylint: disable-next = undefined-variable
 if "autodoc" in tags:  # noqa: F821

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@
 
 # Standard library imports
 import datetime
+import os
 import sys
 from pathlib import Path
 
@@ -246,6 +247,9 @@ autodoc_member_order = "bysource"
 # Default flags used by autodoc directives
 autodoc_default_options = {
     "members": True,
+    "private-members": "_",
+    "special-members": True,
+    "exclude-members": "__weakref__",
     "show-inheritance": True,
 }
 
@@ -271,6 +275,7 @@ autosummary_context = {
 # pylint: disable-next = undefined-variable
 if "autodoc" in tags:  # noqa: F821
     autosummary_generate = True
+    os.environ["SPHINX_AUTODOC"] = "1"
 else:
     autosummary_generate = False
     suppress_warnings += ["autodoc", "autosummary", "toc.excluded"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 myst-parser>=1,<5  # Docs markup; cap to support wide range of py versions
-sphinx>=5,<9  # Docs generator; cap to range confirmed supported by deps
+sphinx>=6.2,<9  # Docs generator; cap to range confirmed supported by deps
 sphinx-book-theme>=1,<2  # Docs theme; cap to support wide range of py versions
+sphinx-qt-documentation>=0.4.1,<1  # Crossrefs to Qt documentation


### PR DESCRIPTION
# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-api-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch
* [x] Checked your code and writing carefully
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

Requires spyder-ide/spyder#25435 to be merged first, and this PR rebased accordingly.

* Thoroughly revise the docstring content in the `spyder` submodule for the top-level `spyder.api` modules, `__init__.py` s and `_version.py`
	* Ensure all modules and APIs have a proper summary line
	* Document un(der) documented public APIs
	* Greatly clarify and expand existing descriptions
	* Add all param, return and attribute types to both signatures and docstrings
	* Add and fix Sphinx roles and directives throughout
	* Fix all Sphinx broken references in the affected modules
	* Inline Spyder API `__version__` into `spyder.api`
	* Also add/revise `get_translation` and `_` (`translate_gettext`) in `spyder.config.base`
* Enable showing dunders and fix all syntax errors/warnings in them
* Set a new env variable, `SPHINX_AUTODOC`, when building, add a helper `building_autodoc()` in `spyder.config.base` to check it, and use it to swap in correct function/docstring for `_` (`translate_gettext`)
* Add infrastructure for hiding semi-private/non-canonical modules (`spyder.api.editor`, `spyder.api.plugins.new_api`, `spyder.api.plugins.enum`, `spyder.api.tests`, test modules, etc).
* Add `conf.py` config and a new PyQt5 intersphinx target and `sphinx-qt-documentation` plugin (disabled for now on non-autodoc builds as it requires Qt installed) to fix most broken reference warnings, including those due to:
    * Qt
    * type aliases
    * ref name aliasing
    * classmethods/class bases
    * type params/paramspec
    * Numpydoc `optional`, and
    * Spyder modules not (yet) included in the build

Additionally, in Spyder, ensure `_` (`translate_gettext`) is always imported from the canonical location in `spyder.api.translations` rather than `spyder.config.base`.

<!--- Thanks for your help making Spyder-API-Docs better for everyone! --->
