### PR TITLE
Integrate new & revised docstrings in `spyder.api.widgets` module

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,9 @@ pygments_style = "sphinx"
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Maximum length of function signature to show wrapped in a single logical line
+python_maximum_signature_line_length = 80
+
 # Intersphinx configuration
 # pylint: disable-next = consider-using-namedtuple-or-dataclass
 intersphinx_mapping = {
@@ -118,6 +121,8 @@ nitpick_ignore_regex = {
         # pylint: disable-next = line-too-long
         "spyder.(app|config|fonts|images|locale|plugins|tests|utils|widgets|windows).*",  # noqa: E501
     ),
+    # Private APIs
+    ("py:class", "spyder.api.widgets.comboboxes._SpyderComboBoxMixin"),
     # Numpydoc optional
     ("py:class", "optional"),
     # Typing params
@@ -137,6 +142,8 @@ nitpick_ignore_regex = {
     ("py:class", "spyder.api.preferences.OptionSet"),
     ("py:class", "SpyderPluginClass"),
     ("py:class", "spyder.api.plugin_registration.registry.SpyderPluginClass"),
+    ("py:class", "ToolbarItem"),
+    ("py:class", "spyder.api.widgets.toolbars.ToolbarItem"),
 }
 
 
@@ -307,6 +314,8 @@ autodoc_type_aliases = {
     "SpyderPluginClass": (
         "spyder.api.plugin_registration.registry.SpyderPluginClass"
     ),
+    "ToolbarItem": "spyder.api.widgets.toolbars.ToolbarItem",
+    "ToolbarItemEntry": "spyder.api.widgets.toolbars.ToolbarItemEntry",
     # Ref name aliases
     "AbstractEventLoop": "asyncio.AbstractEventLoop",
     "asyncio.AbstractEventLoop": "asyncio.AbstractEventLoop",

--- a/noxfile.py
+++ b/noxfile.py
@@ -164,9 +164,6 @@ def construct_sphinx_invocation(
     builder = builders[-1] if builders else builder
     build_dir = BUILD_DIR / builder if build_dir is None else build_dir
 
-    if "autodoc" in cli_options:
-        build_options = [item for item in build_options if item != "-n"]
-
     if CI:
         build_options = list(build_options) + ["--color"]
 


### PR DESCRIPTION
# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-api-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch
* [x] Checked your code and writing carefully
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

Requires spyder-ide/spyder#25598

* Thoroughly revise the docstring content for the `spyder.api.widgets` modules:
	* Ensure all modules and APIs have a proper summary line
	* Document un(der) documented public APIs
	* Greatly clarify and expand existing descriptions
	* Add all param, return and attribute types to both signatures and docstrings
	* Fix and clarify many instances of missing, incorrect or unclear param types in the signature and docstrings related to parameters accepting `None` and/or having a default value, and clarify in the docstring what that value is and its meaning.
	* Add and fix Sphinx roles and directives throughout
	* Fix all Sphinx broken references in the affected modules
* Document several other API issues across the touched modules:
    - Add pending deprecation of ToolbarStyle and SpyderMenuProxyStyle and replacement with the corresponding private names, as they were never intended to be used publicly
    - Document not specifying a known `TYPE` for `ToolbarStyle` raise a SpyderAPIError rather than silently not working as intended
    - Add admonition in `SpyderToolbar` to not use it directly in favor of its subclasses `ApplicationToolbar` and `MainWidgetToolbar`
    - Document removal of `options` arg from `SpyderActionMixin.update_actions()` mixin, which is inconsistent and incompatible with all its actual implementations and already will raise an error at runtime


<!--- Thanks for your help making Spyder-API-Docs better for everyone! --->
